### PR TITLE
PULSE-413: Updated README with instructions regarding `keys.sql` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 /build/
+keys.sql

--- a/README.md
+++ b/README.md
@@ -17,32 +17,34 @@ $ ./fake.sh
 
 ## Install the pgcrypto Postgres Extension
 
-* To install the extension:
+To install the extension:
 ```sql
 CREATE EXTENSION pgcrypto;
 ```
-* To see which extensions are installed
+To see which extensions are installed
 ```sql
 \dx
 ```
 
 ## Create public and private keys to use for encrypting and decrypting sensitive personal information in the database.
 
-* Install pgp if your system does not have it already. Windows users likely have to install something and Linux users likely do not.
-  * Gnupg4win (https://www.gnupg.org/download/)
+Install pgp if your system does not have it already. Windows users likely have to install something and Linux users likely do not.
+* Gnupg4win (https://www.gnupg.org/download/)
 
-* Create the keys:
+Create the keys:
+
 ```sh
 $ gpg --gen-key
 ```
 
-* Follow the prompts keeping in mind the notes below.
-  * Type 1 (RSA) or Type 2 (DSA) should be fine.
-  * I chose a size of 2048.
-  * You can set an expiration if you'd like, but you probably shouldn't unless you really enjoy following these steps.
-  * DO NOT set a password. Hit enter to leave the password prompts blank and accept all related warnings.
+Follow the prompts keeping in mind the notes below.
+* Type 1 (RSA) or Type 2 (DSA) should be fine.
+* I chose a size of 2048.
+* You can set an expiration if you'd like, but you probably shouldn't unless you really enjoy following these steps.
+* **DO NOT** set a password. Hit enter to leave the password prompts blank and accept all related warnings.
 
-* View the keys you created. The one listed as "sec" is the private key and the other is the public key.
+View the keys you created. The one listed as "sec" is the private key and the other is the public key.
+
 ```sh
 $ gpg --list-secret-keys
 
@@ -51,16 +53,19 @@ uid                  pulse <pulse@ainq.com>
 ssb   2048R/F68178C3 2017-03-30
 ```
 
-* Export the keys in a readable format.
+Export the keys in a readable format.
+
 ```sh
 gpg -a --export F68178C3 > public.key
 gpg -a --export-secret-keys 7049EF5F > private.key
 ```
 
 ## Add the public and private keys as data that will be returned by a database function in Postgres
-* Create the below functions in both the pulse and pulse_test databases.
 
-  * Open the public.key file and copy its contents into a function like the one below. Run the function.
+Add the functions below to a file named `keys.sql` in the root directory of the project. That file will be executed during the reset process to add the functions to both the pulse and pulse_test databases, but not stored in git
+
+Open the public.key file and copy its contents into a function like the one below.
+
 ```sql
 CREATE OR REPLACE FUNCTION pulse.public_key() RETURNS text as $$
 	BEGIN
@@ -74,7 +79,8 @@ inthekey
 $$ LANGUAGE plpgsql;
 ```
 
-  * Open the private.key file and copy its contents into a function like the one below. Run the function.
+Open the private.key file and copy its contents into a function like the one below.
+
 ```sql
 CREATE OR REPLACE FUNCTION pulse.private_key() RETURNS text as $$
 	BEGIN
@@ -90,11 +96,9 @@ thanthepublickey
 $$ LANGUAGE plpgsql;
 ```
 
-  * Test that the functions are working
+Reset the database with `reset.sh` and verify the functions work correctly by running `psql` and executing the below SQL commands
+
 ```sql
 select * from public_key();
 select * from private_key();
 ```
-
-
-

--- a/data-model-views.sql
+++ b/data-model-views.sql
@@ -1,4 +1,4 @@
-DROP VIEW IF EXISTS pulse.patient_discovery_query_stats;
+--DROP VIEW IF EXISTS pulse.patient_discovery_query_stats;
 --CREATE OR REPLACE VIEW pulse.patient_discovery_query_stats AS
 --SELECT 
 --	loc.id as location_id,

--- a/reset.sh
+++ b/reset.sh
@@ -14,5 +14,9 @@ psql -h $host -U $user -f data-model.sql pulse
 psql -h $host -U $user -f data-model.sql pulse_test
 psql -h $host -U $user -f data-model-views.sql pulse
 psql -h $host -U $user -f data-model-views.sql pulse_test
+if [ -f keys.sql ]; then
+    psql -h $host -U $user -f keys.sql pulse
+    psql -h $host -U $user -f keys.sql pulse_test
+fi
 psql -h $host -U $user -f preload.sql pulse
 psql -h $host -U $user -f preload.sql pulse_test


### PR DESCRIPTION
Ran the PGP stuff today and updated README with relevant things. Important is addition of (gitignored) keys.sql file that has both the private & public functions mentioned in the README. The reset script will now load that file during reset, before it's required by the preload sql file.
